### PR TITLE
Adding Category retrieval support

### DIFF
--- a/Runtime/DAO/AbstractDao.cs
+++ b/Runtime/DAO/AbstractDao.cs
@@ -4,9 +4,10 @@ using System.Threading.Tasks;
 
 using Tradelite.SDK.Model;
 
-namespace Tradelite.SDK.DAO {
-
-    public interface AbstractDao<T> where T : BaseModel {
+namespace Tradelite.SDK.DAO
+{
+    public interface AbstractDao<T> where T : BaseModel
+    {
 
         Task<T> Get(string id, Hashtable parameters = null);
         Task<T[]> Select(Hashtable parameters = null);

--- a/Runtime/DAO/HttpDao.cs
+++ b/Runtime/DAO/HttpDao.cs
@@ -8,19 +8,24 @@ using Tradelite.SDK.Model;
 using UnityEngine;
 using UnityEngine.Networking;
 
-namespace Tradelite.SDK.DAO {
-
-    internal static class StaticAuthInfo {
-        public static string jwtToken { get; set; }
+namespace Tradelite.SDK.DAO
+{
+    internal static class StaticAuthInfo
+    {
+        public static string jwtToken
+        { get; set; }
     }
 
-    public class HttpDao<T> : AbstractDao<T> where T : BaseModel {
+    public class HttpDao<T> : AbstractDao<T> where T : BaseModel
+    {
         [Serializable]
-        private class EntityList {
+        private class EntityList
+        {
             public T[] list;
         }
 
-        public static string jwtToken {
+        public static string jwtToken
+        {
             get { return StaticAuthInfo.jwtToken; }
             set { StaticAuthInfo.jwtToken = value; }
         }
@@ -30,39 +35,49 @@ namespace Tradelite.SDK.DAO {
         private string entityName;
         private UTF8Encoding encoder = new UTF8Encoding();
 
-        public HttpDao(string dataSource) {
+        public HttpDao(string dataSource)
+        {
             this.baseUrl = dataSource;
             this.fromS3 = dataSource.ToString().IndexOf("/data") != -1;
             entityName = typeof(T).Name;
         }
 
-        public string composeUrl(string baseUrl) {
+        public string composeUrl(string baseUrl)
+        {
             return composeUrl(baseUrl, null);
         }
 
-        protected string composeUrl(string baseUrl, string id) {
+        protected string composeUrl(string baseUrl, string id)
+        {
             string candidateUrl = baseUrl;
-            if (id != null) {
+            if (id != null)
+            {
                 candidateUrl += "/" + id;
             }
             string extension = (fromS3 ? ".json" : "");
             return candidateUrl + extension;
         }
 
-        protected string appendParameters(string url, Hashtable parameters) {
-            if (parameters == null || parameters.Count == 0) {
+        protected string appendParameters(string url, Hashtable parameters)
+        {
+            if (parameters == null || parameters.Count == 0)
+            {
                 return url;
             }
 
             List<string> combinations = new List<string>();
-            foreach (string key in parameters.Keys) {
+            foreach (string key in parameters.Keys)
+            {
                 var value = parameters[key];
-                if (value.GetType() == typeof(string[])) {
-                    foreach (string individual in ((string[])value)) {
+                if (value.GetType() == typeof(string[]))
+                {
+                    foreach (string individual in ((string[])value))
+                    {
                         combinations.Add(key + "=" + HttpUtility.UrlEncode((string)individual));
                     }
                 }
-                else {
+                else
+                {
                     combinations.Add(key + "=" + HttpUtility.UrlEncode((string)value));
                 }
             }
@@ -70,29 +85,35 @@ namespace Tradelite.SDK.DAO {
             return url + '?' + string.Join("&", combinations);
         }
 
-        protected UnityWebRequest setRequestHeaders(UnityWebRequest request, bool acceptText = false) {
+        protected UnityWebRequest setRequestHeaders(UnityWebRequest request, bool acceptText = false)
+        {
             request.SetRequestHeader("UserAgent", "Unity3D/C#/Tradelite/SDK");
             request.SetRequestHeader("Accept", acceptText ? "text/plain" : "application/json; charset=UTF-8");
             request.SetRequestHeader("Content-Type", "application/json; charset=UTF-8"); // Harmless if not required
-            if (!fromS3 && jwtToken != null) {
+            if (!fromS3 && jwtToken != null)
+            {
                 request.SetRequestHeader("Authorization", "Bearer " + jwtToken);
             }
             return request;
         }
 
-        public virtual async Task<T> Get(string id, Hashtable parameters = null) {
+        public virtual async Task<T> Get(string id, Hashtable parameters = null)
+        {
             string url = appendParameters(composeUrl(baseUrl, id), parameters);
 
-            try {
+            try
+            {
                 using var request = setRequestHeaders(UnityWebRequest.Get(url));
 
                 var operation = request.SendWebRequest();
 
-                while (!operation.isDone) {
+                while (!operation.isDone)
+                {
                     await Task.Yield();
                 }
 
-                if (request.result != UnityWebRequest.Result.Success) {
+                if (request.result != UnityWebRequest.Result.Success)
+                {
                     Debug.LogError($"HttpDao.Get() failed:\n- {request.error}\n- {request.downloadHandler.text}");
                 }
                 else if (request.responseCode == 200) // OK
@@ -102,26 +123,31 @@ namespace Tradelite.SDK.DAO {
                     return JsonUtility.FromJson<T>(jsonPayload);
                 }
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 Debug.LogError($"{nameof(Get)} for {entityName} w/ id: {id} failed with message: {ex.Message}");
             }
 
             return default;
         }
 
-        public virtual async Task<T[]> Select(Hashtable parameters = null) {
+        public virtual async Task<T[]> Select(Hashtable parameters = null)
+        {
             string url = appendParameters(composeUrl(baseUrl), parameters);
 
-            try {
+            try
+            {
                 using var request = setRequestHeaders(UnityWebRequest.Get(url));
 
                 var operation = request.SendWebRequest();
 
-                while (!operation.isDone) {
+                while (!operation.isDone)
+                {
                     await Task.Yield();
                 }
 
-                if (request.result != UnityWebRequest.Result.Success) {
+                if (request.result != UnityWebRequest.Result.Success)
+                {
                     Debug.LogError($"HttpDao.Select() failed:\n- {request.error}\n- {request.downloadHandler.text}");
                 }
                 else if (request.responseCode == 200) // OK
@@ -135,17 +161,20 @@ namespace Tradelite.SDK.DAO {
                     return new T[0];
                 }
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 Debug.LogError($"{nameof(Select)} of {entityName} entities failed with message: {ex.Message}");
             }
 
             return default;
         }
 
-        public virtual async Task<string> Create(T entity) {
+        public virtual async Task<string> Create(T entity)
+        {
             string url = composeUrl(baseUrl);
 
-            try {
+            try
+            {
                 string payload = JsonUtility.ToJson(entity);
 
                 UTF8Encoding encoder = new UTF8Encoding();
@@ -161,11 +190,13 @@ namespace Tradelite.SDK.DAO {
 
                 var operation = request.SendWebRequest();
 
-                while (!operation.isDone) {
+                while (!operation.isDone)
+                {
                     await Task.Yield();
                 }
 
-                if (request.result != UnityWebRequest.Result.Success) {
+                if (request.result != UnityWebRequest.Result.Success)
+                {
                     Debug.LogError($"HttpDao.Create() failed:\n- {request.error}\n- {request.downloadHandler.text}");
                 }
                 else if (request.responseCode == 201) // OK
@@ -175,18 +206,21 @@ namespace Tradelite.SDK.DAO {
                     return location.Substring(location.LastIndexOf('/') + 1);
                 }
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 Debug.LogError($"{nameof(Select)} of {entityName} entities failed with message: {ex.Message}");
             }
 
             return default;
         }
 
-        public virtual Task<string> Update(string id, T partialEntity) {
+        public virtual Task<string> Update(string id, T partialEntity)
+        {
             throw new NotSupportedException();
         }
 
-        public virtual Task Delete(string id) {
+        public virtual Task Delete(string id)
+        {
             throw new NotSupportedException();
         }
     }

--- a/Runtime/DAO/Kb.meta
+++ b/Runtime/DAO/Kb.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c41275af17be04c69af0389ef72603eb
+guid: a9e8d9225d3d24a999fe61a69b6ee411
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Runtime/DAO/Kb/CategoryCatalogDao.cs
+++ b/Runtime/DAO/Kb/CategoryCatalogDao.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using Tradelite.SDK.DAO;
+using Tradelite.SDK.Model.KbScope;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Tradelite.SDK.DAO.KbScope
+{
+
+    public class CategoryCatalogDao : HttpDao<CategoryCatalog>
+    {
+        public CategoryCatalogDao() : base(DataSource.KbCategory)
+        { }
+
+        public async Task<CategoryCatalog> Get()
+        {
+            return await Get("_folderCatalog");
+        }
+    }
+}

--- a/Runtime/DAO/Kb/CategoryCatalogDao.cs.meta
+++ b/Runtime/DAO/Kb/CategoryCatalogDao.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f41e550a47294ddc80283cd87d3014e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/DAO/Kb/CategoryDao.cs
+++ b/Runtime/DAO/Kb/CategoryDao.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using Tradelite.SDK.DAO;
+using Tradelite.SDK.Model.KbScope;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Tradelite.SDK.DAO.KbScope
+{
+
+    public class CategoryDao : HttpDao<Category>
+    {
+        public CategoryDao() : base(DataSource.KbCategory)
+        { }
+
+        public override async Task<Category[]> Select(Hashtable parameters = null)
+        {
+            var idParam = parameters["id"];
+            if (idParam.GetType() == typeof(string[]))
+            {
+                string[] ids = (string[]) idParam;
+                var getRequests = Array.ConvertAll(ids, id => Get(id));
+                return await Task.WhenAll(getRequests);
+            }
+            
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Runtime/DAO/Kb/CategoryDao.cs.meta
+++ b/Runtime/DAO/Kb/CategoryDao.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 118fb62251e7a494db4da7783f9312ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/DAO/LocalStorageDao.cs
+++ b/Runtime/DAO/LocalStorageDao.cs
@@ -8,71 +8,88 @@ using Tradelite.SDK.Model;
 using UnityEngine;
 using UnityEngine.Networking;
 
-namespace Tradelite.SDK.DAO {
-    public class LocalStorageDao<T> : AbstractDao<T> where T : BaseModel {
+namespace Tradelite.SDK.DAO
+{
+    public class LocalStorageDao<T> : AbstractDao<T> where T : BaseModel
+    {
 
         private string entityName;
         private string gameId;
         private bool usePlayerPrefs;
 
-        public LocalStorageDao(string gameId, bool usePlayerPrefs = true) {
+        public LocalStorageDao(string gameId, bool usePlayerPrefs = true)
+        {
             this.usePlayerPrefs = usePlayerPrefs;
             entityName = typeof(T).Name;
         }
 
-        public void SetBasicAuthCredentials(string username, string password) {
+        public void SetBasicAuthCredentials(string username, string password)
+        {
             throw new NotSupportedException();
         }
 
-        public Task<T> Get(string id, Hashtable parameters = null) {
-            try {
+        public Task<T> Get(string id, Hashtable parameters = null)
+        {
+            try
+            {
                 string key = $"_{gameId}_{entityName}_{id}";
-                if (!PlayerPrefs.HasKey(key)) {
+                if (!PlayerPrefs.HasKey(key))
+                {
                     return null;
                 }
 
                 string json = PlayerPrefs.GetString(key);
                 return Task.FromResult(JsonUtility.FromJson<T>(json));
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 Debug.LogError($"{nameof(Get)} for {entityName} w/ id: {id} failed with message: {ex.Message}");
             }
 
             return default;
         }
 
-        public Task<T[]> Select(Hashtable parameters = null) {
+        public Task<T[]> Select(Hashtable parameters = null)
+        {
             throw new NotSupportedException();
         }
 
-        public Task<string> Create(T entity) {
+        public Task<string> Create(T entity)
+        {
             return Create(entity, null);
         }
 
-        public Task<string> Create(T entity, string idOverride) {
-            try {
+        public Task<string> Create(T entity, string idOverride)
+        {
+            try
+            {
                 string key = $"_{gameId}_{entityName}_{(idOverride == null ? entity.id : idOverride)}";
                 PlayerPrefs.SetString(key, JsonUtility.ToJson(entity));
                 return Task.FromResult(entity.id);
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 Debug.LogError($"{nameof(Create)} of {entityName} w/ id: {entity.id} failed with message:: {ex.Message}");
             }
 
             return default;
         }
 
-        public Task<string> Update(string id, T partialEntity) {
+        public Task<string> Update(string id, T partialEntity)
+        {
             throw new NotSupportedException();
         }
 
-        public Task Delete(string id) {
-            try {
+        public Task Delete(string id)
+        {
+            try
+            {
                 string key = $"_{gameId}_{entityName}_{id}";
                 PlayerPrefs.DeleteKey(key);
 
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 Debug.LogError($"{nameof(Delete)} of {entityName} w/ id: {id} failed with message:: {ex.Message}");
             }
 

--- a/Runtime/DAO/User/UserDao.cs
+++ b/Runtime/DAO/User/UserDao.cs
@@ -9,12 +9,16 @@ using Tradelite.SDK.Model.UserScope;
 using UnityEngine;
 using UnityEngine.Networking;
 
-namespace Tradelite.SDK.DAO.UserScope {
+namespace Tradelite.SDK.DAO.UserScope
+{
 
-    public class UserDao : HttpDao<User> {
-        public UserDao() : base(DataSource.User) { }
+    public class UserDao : HttpDao<User>
+    {
+        public UserDao() : base(DataSource.User)
+        { }
 
-        public override Task<User[]> Select(Hashtable parameters = null) {
+        public override Task<User[]> Select(Hashtable parameters = null)
+        {
             throw new InvalidOperationException("User.Select() not supported");
         }
     }

--- a/Runtime/DataSource.cs
+++ b/Runtime/DataSource.cs
@@ -13,8 +13,9 @@ namespace Tradelite.SDK
         public static readonly string Wallet = apiUrl + "/v1/user/wallet";
         // Mogaland knowledge base
         public static readonly string Instrument = cdnUrl + "/data/instrument";
-        public static readonly string QuizQuestion = apiUrl + "/v1/kb/question";
-        public static readonly string QuizAnswer = apiUrl + "/v1/kb/answer";
-        public static readonly string QuizSolution = apiUrl + "/v1/kb/solution";
+        public static readonly string KbCategory = cdnUrl + "/data/kb/category";
+        public static readonly string KbQuestion = apiUrl + "/v1/kb/question";
+        public static readonly string KbAnswer = apiUrl + "/v1/kb/answer";
+        public static readonly string KbSolution = apiUrl + "/v1/kb/solution";
     }
 }

--- a/Runtime/Model/BaseError.cs
+++ b/Runtime/Model/BaseError.cs
@@ -1,22 +1,27 @@
 using System;
 using System.Collections.Generic;
 
-namespace Tradelite.SDK.Model {
+namespace Tradelite.SDK.Model
+{
     [Serializable]
-    public class BaseError {
+    public class BaseError
+    {
         public string message;
         public Exception cause;
 
-        public BaseError(string message) {
+        public BaseError(string message)
+        {
             this.message = message;
         }
 
-        public BaseError(string message, Exception cause) {
+        public BaseError(string message, Exception cause)
+        {
             this.message = message;
             this.cause = cause;
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             List<string> output = new List<string>();
             if (!string.IsNullOrEmpty(message)) output.Add($"message: `{message}`");
             if (cause != null) output.Add($"cause: `{cause.ToString()}`");

--- a/Runtime/Model/BaseModel.cs
+++ b/Runtime/Model/BaseModel.cs
@@ -1,16 +1,19 @@
 using System;
 using System.Collections.Generic;
 
-namespace Tradelite.SDK.Model {
+namespace Tradelite.SDK.Model
+{
     [Serializable]
-    public class BaseModel {
+    public class BaseModel
+    {
         public string id;
         public long version = 1;
         public long created;
         public long updated;
         public string authorId;
 
-        public override string ToString() {
+        public override string ToString()
+        {
             List<string> output = new List<string>();
             if (!string.IsNullOrEmpty(id)) output.Add($"id: `{id}`");
             if (version != 1) output.Add($"version: {version}");

--- a/Runtime/Model/Config.meta
+++ b/Runtime/Model/Config.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: f82bb5777cda64821af8886929abc3c7
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Model/Kb.meta
+++ b/Runtime/Model/Kb.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ffa4c348fd9fb4d5694b8792ad9e7cfd
+guid: 4db348818d36646c69769393778dc9a1
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Runtime/Model/Kb/Category.cs
+++ b/Runtime/Model/Kb/Category.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+using Tradelite.SDK.Model;
+
+namespace Tradelite.SDK.Model.KbScope
+{
+    [Serializable]
+    public class Category : BaseModel
+    {
+        public string title = null;
+        public string imageId = null;
+        public string imageUrl = null;
+
+        public override string ToString()
+        {
+            List<string> output = new List<string>();
+            string baseToString = base.ToString();
+            if (!string.IsNullOrEmpty(baseToString)) output.Add(baseToString);
+
+            if (!string.IsNullOrEmpty(title)) output.Add($"title: `{title}`");
+            if (!string.IsNullOrEmpty(imageId)) output.Add($"imageId: `{imageId}`");
+            if (!string.IsNullOrEmpty(imageUrl)) output.Add($"imageUrl: `{imageUrl}`");
+
+            return String.Join(", ", output);
+        }
+    }
+}

--- a/Runtime/Model/Kb/Category.cs.meta
+++ b/Runtime/Model/Kb/Category.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 889c341dc67794df7956e5686e4731b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/Kb/CategoryCatalog.cs
+++ b/Runtime/Model/Kb/CategoryCatalog.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 
 using Tradelite.SDK.Model;
 
-namespace Tradelite.SDK.Model.UserScope
+namespace Tradelite.SDK.Model.KbScope
 {
     [Serializable]
-    public class User : BaseModel
+    public class CategoryCatalog : BaseModel
     {
-        public string email = null;
-        public string nickname = null;
+        public string title = null;
+        public string[] categoryIds;
 
         public override string ToString()
         {
@@ -17,8 +17,8 @@ namespace Tradelite.SDK.Model.UserScope
             string baseToString = base.ToString();
             if (!string.IsNullOrEmpty(baseToString)) output.Add(baseToString);
 
-            if (!string.IsNullOrEmpty(email)) output.Add($"email: `{email}`");
-            if (!string.IsNullOrEmpty(nickname)) output.Add($"nickname: `{nickname}`");
+            if (!string.IsNullOrEmpty(title)) output.Add($"title: `{title}`");
+            if (0 < categoryIds.Length) output.Add($"categoryIds: `{categoryIds}`");
 
             return String.Join(", ", output);
         }

--- a/Runtime/Model/Kb/CategoryCatalog.cs.meta
+++ b/Runtime/Model/Kb/CategoryCatalog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f2f2316d836543e9b8e1de460d3c200
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/Knowledge.meta
+++ b/Runtime/Model/Knowledge.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7bae1fa37e05443b3933379cfd9e316a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Model/User/Session.cs
+++ b/Runtime/Model/User/Session.cs
@@ -6,10 +6,14 @@ using Tradelite.SDK.Model;
 namespace Tradelite.SDK.Model.UserScope
 {
     [Serializable]
-    public class User : BaseModel
+    public class Session : BaseModel
     {
-        public string email = null;
-        public string nickname = null;
+        public string locale = "en";
+
+        public void SetLocale(string locale = "en")
+        {
+            this.locale = locale;
+        }
 
         public override string ToString()
         {
@@ -17,8 +21,7 @@ namespace Tradelite.SDK.Model.UserScope
             string baseToString = base.ToString();
             if (!string.IsNullOrEmpty(baseToString)) output.Add(baseToString);
 
-            if (!string.IsNullOrEmpty(email)) output.Add($"email: `{email}`");
-            if (!string.IsNullOrEmpty(nickname)) output.Add($"nickname: `{nickname}`");
+            if (!string.IsNullOrEmpty(locale)) output.Add($"locale: `{locale}`");
 
             return String.Join(", ", output);
         }

--- a/Runtime/Model/User/Session.cs.meta
+++ b/Runtime/Model/User/Session.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fb8f151266a84f28a82b1d1890890e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Service/BaseService.cs
+++ b/Runtime/Service/BaseService.cs
@@ -6,64 +6,83 @@ using Tradelite.SDK.DAO;
 using Tradelite.SDK.Model;
 using Tradelite.SDK.Service;
 
-namespace Tradelite.SDK.Service {
-    public class BaseService<T> where T : BaseModel {
+namespace Tradelite.SDK.Service
+{
+    public class BaseService<T> where T : BaseModel
+    {
         protected AbstractDao<T> dao;
         protected string entityName;
 
-        protected BaseService() {
+        protected BaseService()
+        {
             entityName = typeof(T).Name;
         }
 
-        public virtual async Task<T> Get(string id, Hashtable parameters = null) {
+        public virtual async Task<T> Get(string id, Hashtable parameters = null)
+        {
             return await dao.Get(id, parameters);
         }
 
-        public async void Get(string id, Hashtable parameters, Action<T> success, Action<BaseError> failure) {
-            try {
+        public async void Get(string id, Hashtable parameters, Action<T> success, Action<BaseError> failure)
+        {
+            try
+            {
                 success?.Invoke(await Get(id, parameters));
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 failure?.Invoke(new BaseError($"Cannot get entity of class {entityName} with id: {id}", ex));
             }
         }
 
-        public virtual async Task<T[]> Select(Hashtable parameters = null) {
+        public virtual async Task<T[]> Select(Hashtable parameters = null)
+        {
             return await dao.Select(parameters);
         }
 
-        public async void Select(Hashtable parameters, Action<T[]> success, Action<BaseError> failure) {
-            try {
+        public async void Select(Hashtable parameters, Action<T[]> success, Action<BaseError> failure)
+        {
+            try
+            {
                 success?.Invoke(await Select(parameters));
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 failure?.Invoke(new BaseError($"Cannot select entities of class {entityName}", ex));
             }
         }
 
-        public virtual async Task<string> Create(T entity) {
+        public virtual async Task<string> Create(T entity)
+        {
             return await dao.Create(entity);
         }
 
-        public async void Create(T entity, Action<string> success, Action<BaseError> failure) {
-            try {
+        public async void Create(T entity, Action<string> success, Action<BaseError> failure)
+        {
+            try
+            {
                 success?.Invoke(await Create(entity));
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 failure?.Invoke(new BaseError($"Cannot create entity of class {entityName}", ex));
             }
         }
  
-        public async virtual Task Delete(string id) {
+        public async virtual Task Delete(string id)
+        {
             await dao.Delete(id);
         }
 
-        public async void Delete(string id, Action success, Action<BaseError> failure) {
-            try {
+        public async void Delete(string id, Action success, Action<BaseError> failure)
+        {
+            try
+            {
                 await Delete(id);
                 success?.Invoke();
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 failure?.Invoke(new BaseError($"Cannot delete entity of class {entityName} w/ id {id}", ex));
             }
         }    }

--- a/Runtime/Service/Config.meta
+++ b/Runtime/Service/Config.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ad63c524417794de2b90464db8e2df4e
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Service/Kb.meta
+++ b/Runtime/Service/Kb.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 850ea809bd57245078732af4b0830f2c
+guid: 79a6470a557464c55a8c64aa828b0ad6
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Runtime/Service/Kb/CategoryService.cs
+++ b/Runtime/Service/Kb/CategoryService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+
+using Tradelite.SDK.DAO.KbScope;
+using Tradelite.SDK.Model.KbScope;
+using Tradelite.SDK.Service;
+
+namespace Tradelite.SDK.Service.KbScope
+{
+    public class CategoryService : BaseService<Category>
+    {
+        private static CategoryService INSTANCE = null;
+
+        public static CategoryService GetInstance(Boolean forceReload = false)
+        {
+            if (INSTANCE == null || forceReload)
+            {
+                INSTANCE = new CategoryService();
+            }
+            return INSTANCE;
+        }
+
+        private CategoryCatalogDao catalogDao;
+
+        private CategoryService() : base()
+        {
+            dao = new CategoryDao();
+            catalogDao = new CategoryCatalogDao();
+        }
+
+        public async Task<string[]> GetIds()
+        {
+            return (await catalogDao.Get()).categoryIds;
+        }
+
+        public async Task<Category[]> GetByIds(string[] ids)
+        {
+            Hashtable parameters = new Hashtable();
+            parameters.Add("id", ids);
+            return await dao.Select(parameters);
+        }
+    }
+}

--- a/Runtime/Service/Kb/CategoryService.cs.meta
+++ b/Runtime/Service/Kb/CategoryService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 681a931408538406d8292860df2422dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Service/Knowledge.meta
+++ b/Runtime/Service/Knowledge.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: d9bfbbc6edae94f03b7198aaa1d1fbae
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Service/User/SessionService.cs
+++ b/Runtime/Service/User/SessionService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+
+using Tradelite.SDK.DAO.UserScope;
+using Tradelite.SDK.Model.UserScope;
+using Tradelite.SDK.Service;
+
+namespace Tradelite.SDK.Service.UserScope
+{
+    public class SessionService
+    {
+        private static SessionService INSTANCE = null;
+
+        public static SessionService GetInstance(Boolean forceReload = false)
+        {
+            if (INSTANCE == null || forceReload)
+            {
+                INSTANCE = new SessionService();
+            }
+            return INSTANCE;
+        }
+
+        private Session session;
+
+        private SessionService() : base()
+        {
+            session = new Session();
+        }
+
+        public void SetLocale(String locale = "en")
+        {
+            session.locale = locale;
+        }
+    }
+}

--- a/Runtime/Service/User/SessionService.cs.meta
+++ b/Runtime/Service/User/SessionService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afa4446d7586243719362ee5bf381515
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Service/User/UserService.cs
+++ b/Runtime/Service/User/UserService.cs
@@ -6,18 +6,23 @@ using Tradelite.SDK.DAO.UserScope;
 using Tradelite.SDK.Model.UserScope;
 using Tradelite.SDK.Service;
 
-namespace Tradelite.SDK.Service.UserScope {
-    public class UserService : BaseService<User> {
+namespace Tradelite.SDK.Service.UserScope
+{
+    public class UserService : BaseService<User>
+    {
         private static UserService INSTANCE = null;
 
-        public static UserService GetInstance(Boolean forceReload = false) {
-            if (INSTANCE == null || forceReload) {
+        public static UserService GetInstance(Boolean forceReload = false)
+        {
+            if (INSTANCE == null || forceReload)
+            {
                 INSTANCE = new UserService();
             }
             return INSTANCE;
         }
 
-        private UserService() : base() {
+        private UserService() : base()
+        {
             dao = new UserDao();
         }
     }


### PR DESCRIPTION
- New service to retrieve the Knowledge Base (kb) Categories
  - One access point to get their identifiers (so a smart selection can be made to load the most important quickly, the others being loaded in the background).
  - One access point to get a category by its identifiers
  - One access point to get many categories at once from a list of identifiers
  - Example:
``` c#
            CategoryService categoryService = CategoryService.GetInstance();
            
            string[] categoryIds = await categoryService.GetIds();
            Debug.Log($"{categoryIds.Length} category ids retrieved.");
            
            Category[] categories = await categoryService.GetByIds(categoryIds);
            Debug.Log(Categories retrieved. Example: " + categories[0].title);
```
- Preparation of a session record for the SDK to keep track of the user's preferred language.